### PR TITLE
ignore ticket budgets when calculating total budget

### DIFF
--- a/dashboards/apps/turns/data.py
+++ b/dashboards/apps/turns/data.py
@@ -28,11 +28,7 @@ def turns_data(_credentials):
         lambda row: (
             np.nan_to_num(row['project_estimated_cost']) + 
             np.nan_to_num(row['occupancy_inspection_estimated_cost']) + 
-            np.nan_to_num(row['buyers_inspection_estimated_cost']) + 
-            (np.nan_to_num(row['project_ticket_approved_budgets']) +
-             np.nan_to_num(row['occupancy_inspection_ticket_approved_budgets']) +
-             np.nan_to_num(row['buyers_inspection_ticket_approved_budgets']) 
-            if row['fund'] != 'Homevest Real Estate Partners IV - Limestone, L.P.' else 0)
+            np.nan_to_num(row['buyers_inspection_estimated_cost'])
         ),
         axis=1
     )
@@ -44,12 +40,11 @@ def construction_scopes_data(_credentials):
     query = """
         SELECT
             project_id,
-            most_recent_rental_id, 
-            type, 
-            project_status, 
-            project_estimated_cost, 
-            ticket_approved_budgets
-        FROM `homevest-data.dbt_prod.dim_construction_scopes` 
+            most_recent_rental_id,
+            type,
+            project_status,
+            project_estimated_cost
+        FROM `homevest-data.dbt_prod.dim_construction_scopes`
     """
     return pd.read_gbq(query, credentials=_credentials)
 

--- a/dashboards/apps/turns/tabs/economic_turn_costs_tab.py
+++ b/dashboards/apps/turns/tabs/economic_turn_costs_tab.py
@@ -26,15 +26,11 @@ def economic_turn_costs_filters(turns_df):
 def economic_turn_costs(turns_df):
     st.subheader("Economic Turn Costs")
 
-    turns_df['project_budget'] = turns_df.apply(
-        lambda row: row['project_estimated_cost'] if row['fund'] == 'Homevest Real Estate Partners IV - Limestone, L.P.' 
-        else row['project_estimated_cost'] + row['project_ticket_approved_budgets'], 
-        axis=1
-    )
+    turns_df['project_budget'] = turns_df['project_estimated_cost']
 
     turns_df['project_end_date'] = pd.to_datetime(turns_df['project_end_date']).dt.strftime('%Y-%m-%d')
     turns_df['last_change_order_date'] = pd.to_datetime(turns_df['last_change_order_date']).dt.strftime('%Y-%m-%d')
-    
+
     economic_turn_costs_df = turns_df[[
         'address', 
         'state', 
@@ -50,7 +46,6 @@ def economic_turn_costs(turns_df):
         'project_finished_qc_date',
         'project_total_estimated_cost', 
         'project_estimated_cost',
-        'project_ticket_approved_budgets', 
         'project_invoiced_cost',
         'last_invoice_date',
         'last_change_order_date', 
@@ -63,7 +58,6 @@ def economic_turn_costs(turns_df):
         'occupancy_inspection_start_date', 
         'occupancy_inspection_end_date', 
         'occupancy_inspection_estimated_cost', 
-        'occupancy_inspection_ticket_approved_budgets', 
         'occupancy_inspection_count', 
         'occupancy_inspection_at', 
         'occupancy_inspection_status', 
@@ -71,7 +65,6 @@ def economic_turn_costs(turns_df):
         'buyers_inspection_start_date', 
         'buyers_inspection_end_date', 
         'buyers_inspection_estimated_cost', 
-        'buyers_inspection_ticket_approved_budgets', 
         'total_invoiced_cost_before_move_out', 
         'total_invoiced_cost_during_vacancy', 
         'total_invoiced_cost_after_move_in'

--- a/dashboards/apps/turns/tabs/individual_turn_drilldown_tab.py
+++ b/dashboards/apps/turns/tabs/individual_turn_drilldown_tab.py
@@ -84,16 +84,11 @@ def individual_turn_budget_breakdown(selected_turn_arr, filtered_construction_sc
                 width=200,
                 help=f"[Hudson Project ↪](https://hudson.upandup.co/construction/projects/{row['project_id']})"
             )
-            if selected_turn_arr['fund'] != 'Homevest Real Estate Partners IV - Limestone, L.P.':
-                st.metric('Ticket Approved Budgets', 
-                    f"${0 if pd.isna(row['ticket_approved_budgets']) else row['ticket_approved_budgets']:,.2f}", 
-                    width=200,
-                    help='Sum of the approved budgets of all tickets associated with this project'
-                )
 
+        st.markdown("**Associated Latchel Tickets**")
         display_df = tickets_df[tickets_df['project_id'] == row['project_id']]
         display_df['link'] = display_df['slug'].apply(lambda slug: f"https://app.latchel.com/admin/work-order/{slug}")
-        display_df = display_df[['external_source', 'link', 'title', 'category', 'vendor_name', 'description', 'approved_budgets', 'status', 'tracking_status']]
+        display_df = display_df[['link', 'title', 'category', 'vendor_name', 'description', 'approved_budgets', 'status', 'tracking_status']]
         display_df.columns = [col.replace('_', ' ').title() for col in display_df.columns]
         if not display_df.empty:
             st.dataframe(
@@ -112,9 +107,8 @@ def individual_turn_budget_breakdown(selected_turn_arr, filtered_construction_sc
             st.divider()
 
 
-
 def individual_turn_drilldown(filtered_line_items_df):
-    st.subheader("Line Items")
+    st.subheader("Invoices (Buildium)")
     output_df = filtered_line_items_df[[
         'date',
         'vendor_contact_name',


### PR DESCRIPTION
since we are going to start budgeting multiple items per project, using the sum of approved Latchel tickets' budgets is no longer a good estimate of the total budget

(still should add a display that shows each of the individual budgeted line items)